### PR TITLE
Use correct andromeda background color

### DIFF
--- a/colors/sonokai-andromeda.conf
+++ b/colors/sonokai-andromeda.conf
@@ -1,4 +1,4 @@
-background #2b2d37
+background #2b2d3a
 foreground #e1e3e4
 
 selection_background #3a3e4e


### PR DESCRIPTION
The correct background color of sonokai andromeda is: `#2b2d3a` as seen [here](https://github.com/sainnhe/sonokai/blob/master/colors/sonokai.vim#L59)

I just realized it when comparing it to the alacritty terminal theme implementation. 